### PR TITLE
Fix: Wrong API Call, Naming and Lint Warnings

### DIFF
--- a/cloudflare.py
+++ b/cloudflare.py
@@ -101,10 +101,13 @@ def create_gateway_policy(name: str, list_ids: List[str]):
     return r.json()["result"]
 
 
-def update_gateway_policy(policy_id: str, list_ids: List[str]):
+def update_gateway_policy(name: str, policy_id: str, list_ids: List[str]):
     r = session.put(
         f"https://api.cloudflare.com/client/v4/accounts/{CF_IDENTIFIER}/gateway/rules/{policy_id}",
         json={
+            "name": name,
+            "action": "block",
+            "enabled": True,
             "traffic": "or".join([f"any(dns.domains[*] in ${l})" for l in list_ids]),
         },
     )

--- a/cloudflare.py
+++ b/cloudflare.py
@@ -68,7 +68,6 @@ def get_firewall_policies(name_prefix: str):
     )
 
     logger.debug(f"[get_firewall_policies] {r.status_code}")
-    logger.debug(f"{r.json()}")
 
     if r.status_code != 200:
         raise Exception("Failed to get Cloudflare firewall policies")

--- a/cloudflare.py
+++ b/cloudflare.py
@@ -1,3 +1,4 @@
+from typing import List
 import requests
 import logging
 import os
@@ -5,9 +6,9 @@ import os
 logger = logging.getLogger("cloudflare")
 
 CF_API_TOKEN = os.environ["CF_API_TOKEN"]
-CF_ZONE_ID = os.environ["CF_ZONE_ID"]
+CF_IDENTIFIER = os.environ["CF_IDENTIFIER"]
 
-if not CF_API_TOKEN or not CF_ZONE_ID:
+if not CF_API_TOKEN or not CF_IDENTIFIER:
     raise Exception("Missing Cloudflare credentials")
 
 session = requests.Session()
@@ -16,7 +17,7 @@ session.headers.update({"Authorization": f"Bearer {CF_API_TOKEN}"})
 
 def get_lists(name_prefix: str):
     r = session.get(
-        f"https://api.cloudflare.com/client/v4/accounts/{CF_ZONE_ID}/gateway/lists",
+        f"https://api.cloudflare.com/client/v4/accounts/{CF_IDENTIFIER}/gateway/lists",
     )
 
     logger.debug(f"[get_lists] {r.status_code}")
@@ -29,9 +30,9 @@ def get_lists(name_prefix: str):
     return [l for l in lists if l["name"].startswith(name_prefix)]
 
 
-def create_list(name: str, domains: list[str]):
+def create_list(name: str, domains: List[str]):
     r = session.post(
-        f"https://api.cloudflare.com/client/v4/accounts/{CF_ZONE_ID}/gateway/lists",
+        f"https://api.cloudflare.com/client/v4/accounts/{CF_IDENTIFIER}/gateway/lists",
         json={
             "name": name,
             "description": "Created by script.",
@@ -50,7 +51,7 @@ def create_list(name: str, domains: list[str]):
 
 def delete_list(list_id: str):
     r = session.delete(
-        f"https://api.cloudflare.com/client/v4/accounts/{CF_ZONE_ID}/gateway/lists/{list_id}",
+        f"https://api.cloudflare.com/client/v4/accounts/{CF_IDENTIFIER}/gateway/lists/{list_id}",
     )
 
     logger.debug(f"[delete_list] {r.status_code}")
@@ -63,10 +64,11 @@ def delete_list(list_id: str):
 
 def get_firewall_policies(name_prefix: str):
     r = session.get(
-        f"https://api.cloudflare.com/client/v4/accounts/{CF_ZONE_ID}/firewall/access_rules/rules",
+        f"https://api.cloudflare.com/client/v4/accounts/{CF_IDENTIFIER}/gateway/rules",
     )
 
     logger.debug(f"[get_firewall_policies] {r.status_code}")
+    logger.debug(f"{r.json()}")
 
     if r.status_code != 200:
         raise Exception("Failed to get Cloudflare firewall policies")
@@ -76,9 +78,9 @@ def get_firewall_policies(name_prefix: str):
     return [l for l in lists if l["name"].startswith(name_prefix)]
 
 
-def create_gateway_policy(name: str, list_ids: list[str]):
+def create_gateway_policy(name: str, list_ids: List[str]):
     r = session.post(
-        f"https://api.cloudflare.com/client/v4/accounts/{CF_ZONE_ID}/gateway/rules",
+        f"https://api.cloudflare.com/client/v4/accounts/{CF_IDENTIFIER}/gateway/rules",
         json={
             "name": name,
             "description": "Created by script.",
@@ -100,9 +102,9 @@ def create_gateway_policy(name: str, list_ids: list[str]):
     return r.json()["result"]
 
 
-def update_gateway_policy(policy_id: str, list_ids: list[str]):
+def update_gateway_policy(policy_id: str, list_ids: List[str]):
     r = session.put(
-        f"https://api.cloudflare.com/client/v4/accounts/{CF_ZONE_ID}/gateway/rules/{policy_id}",
+        f"https://api.cloudflare.com/client/v4/accounts/{CF_IDENTIFIER}/gateway/rules/{policy_id}",
         json={
             "traffic": "or".join([f"any(dns.domains[*] in ${l})" for l in list_ids]),
         },

--- a/main.py
+++ b/main.py
@@ -63,7 +63,7 @@ class App:
         else:
             self.logger.info("Updating firewall policy")
 
-            cloudflare.update_gateway_policy(cf_policies[0]["id"], [l["id"] for l in cf_lists])
+            cloudflare.update_gateway_policy(f"{self.name_prefix} Block Ads", cf_policies[0]["id"], [l["id"] for l in cf_lists])
 
         self.logger.info("Done")
 

--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 import logging
 import pathlib
+from typing import List
 import requests
 import cloudflare
 
@@ -110,7 +111,7 @@ class App:
 
         return domains
 
-    def chunk_list(self, _list: list[str], n: int):
+    def chunk_list(self, _list: List[str], n: int):
         for i in range(0, len(_list), n):
             yield _list[i : i + n]
 


### PR DESCRIPTION
fix: wrong api call for getting zero trust gateway firewall policies

fix: naming of account identifier
> `ZONE_ID` is used to identify each domains and websites in one user's account. However, Zero Trust is sort of a "account level" service. According to Cloudflare's API doc, it requires an `identifier` for the user, which should be the Account ID. Therefore, the naming of this variable is changed to avoid confusion.

fix: Pylance lint warning of use of "list[str]" (should use List[str] instead)